### PR TITLE
Add missing api services

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ All API Endpoint client are available as services, they follow the official docu
     @mangopay.sdk.api_wallet.service
     @mangopay.sdk.api_pay_ins.service
     @mangopay.sdk.api_pay_outs.service
-    @mangopay.sdk.api_transfert.service:
+    @mangopay.sdk.api_transfert.service (deprecated in 1.1, replaced by @mangopay.sdk.api_transfers.service)
+    @mangopay.sdk.api_transfers.service
     @mangopay.sdk.api_cards.service
     @mangopay.sdk.api_card_registrations.service
     @mangopay.sdk.api_card_pre_authorizations.service

--- a/README.md
+++ b/README.md
@@ -18,8 +18,18 @@ All API Endpoint client are available as services, they follow the official docu
     @mangopay.sdk.api_transfert.service:
     @mangopay.sdk.api_cards.service
     @mangopay.sdk.api_card_registrations.service
-    @mangopay.sdk.api_card_pre_authorizations.service:
+    @mangopay.sdk.api_card_pre_authorizations.service
     @mangopay.sdk.api_refunds.service
+    @mangopay.sdk.api_banking_aliases
+    @mangopay.sdk.api_hooks
+    @mangopay.sdk.api_responses
+    @mangopay.sdk.api_kyc_documents
+    @mangopay.sdk.api_clients
+    @mangopay.sdk.api_events
+    @mangopay.sdk.api_disputes
+    @mangopay.sdk.api_dispute_documents
+    @mangopay.sdk.api_mandates
+    @mangopay.sdk.api_reports
     
 The bundle manage the connection and the authentication on Mango's servers, it needs only the 
 definition of these parmeters

--- a/src/Teknoo/MangoPayBundle/Resources/config/services.yml
+++ b/src/Teknoo/MangoPayBundle/Resources/config/services.yml
@@ -18,7 +18,8 @@ parameters:
   mangopay.sdk.api_wallet.class: 'MangoPay\ApiWallets'
   mangopay.sdk.api_pay_ins.class: 'MangoPay\ApiPayIns'
   mangopay.sdk.api_pay_outs.class: 'MangoPay\ApiPayOuts'
-  mangopay.sdk.api_transfert.class: 'MangoPay\ApiTransfers'
+  mangopay.sdk.api_transfers.class: 'MangoPay\ApiTransfers'
+  mangopay.sdk.api_transfert.class: '%mangopay.sdk.api_transfers.class%'
   mangopay.sdk.api_cards.class: 'MangoPay\ApiCards'
   mangopay.sdk.api_card_registrations.class: 'MangoPay\ApiCardRegistrations'
   mangopay.sdk.api_card_pre_authorizations.class: 'MangoPay\ApiCardPreAuthorizations'
@@ -66,9 +67,13 @@ services:
     class: "%mangopay.sdk.api_pay_outs.class%"
     factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiPayOuts']
 
-  mangopay.sdk.api_transfert.service:
+  mangopay.sdk.api_transfers.service:
     class: "%mangopay.sdk.api_transfert.class%"
-    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiTransferts']
+    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiTransfers']
+
+  mangopay.sdk.api_transfert.service:
+    alias: 'mangopay.sdk.api_transfers.service'
+    deprecated: The "%service_id%" service is deprecated since 1.1 and will be removed in 2.0.
 
   mangopay.sdk.api_cards.service:
     class: "%mangopay.sdk.api_cards.class%"

--- a/src/Teknoo/MangoPayBundle/Resources/config/services.yml
+++ b/src/Teknoo/MangoPayBundle/Resources/config/services.yml
@@ -23,6 +23,16 @@ parameters:
   mangopay.sdk.api_card_registrations.class: 'MangoPay\ApiCardRegistrations'
   mangopay.sdk.api_card_pre_authorizations.class: 'MangoPay\ApiCardPreAuthorizations'
   mangopay.sdk.api_refunds.class: 'MangoPay\ApiRefunds'
+  mangopay.sdk.api_banking_aliases.class: 'MangoPay\ApiBankingAliases'
+  mangopay.sdk.api_hooks.class: 'MangoPay\ApiHooks'
+  mangopay.sdk.api_responses.class: 'MangoPay\ApiResponses'
+  mangopay.sdk.api_kyc_documents.class: 'MangoPay\ApiKycDocuments'
+  mangopay.sdk.api_clients.class: 'MangoPay\ApiClients'
+  mangopay.sdk.api_events.class: 'MangoPay\ApiEvents'
+  mangopay.sdk.api_disputes.class: 'MangoPay\ApiDisputes'
+  mangopay.sdk.api_dispute_documents.class: 'MangoPay\ApiDisputeDocuments'
+  mangopay.sdk.api_mandates.class: 'MangoPay\ApiMandates'
+  mangopay.sdk.api_reports.class: 'MangoPay\ApiReports'
 
   #Parameters,
   #routes names for
@@ -75,6 +85,42 @@ services:
   mangopay.sdk.api_refunds.service:
     class: "%mangopay.sdk.api_refunds.class%"
     factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiRefunds']
+
+  mangopay.sdk.api_banking_aliases.service:
+    class: "%mangopay.sdk.api_banking_aliases.class%"
+    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiBankingAliases']
+
+  mangopay.sdk.api_hooks.service:
+    class: "%mangopay.sdk.api_hooks.class%"
+    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiHooks']
+
+  mangopay.sdk.api_responses.service:
+    class: "%mangopay.sdk.api_responses.class%"
+    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiResponses']
+
+  mangopay.sdk.api_kyc_documents.service:
+    class: "%mangopay.sdk.api_kyc_documents.class%"
+    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiKycDocuments']
+
+  mangopay.sdk.api_clients.service:
+    class: "%mangopay.sdk.api_clients.class%"
+    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiClients']
+
+  mangopay.sdk.api_disputes.service:
+    class: "%mangopay.sdk.api_disputes.class%"
+    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiDisputes']
+
+  mangopay.sdk.api_dispute_documents.service:
+    class: "%mangopay.sdk.api_dispute_documents.class%"
+    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiDisputeDocuments']
+
+  mangopay.sdk.api_mandates.service:
+    class: "%mangopay.sdk.api_mandates.class%"
+    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiMandates']
+
+  mangopay.sdk.api_reports.service:
+    class: "%mangopay.sdk.api_reports.class%"
+    factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiReports']
 
   #bundle services
   teknoo.mangopaybundle.transcriber.users:

--- a/src/Teknoo/MangoPayBundle/Service/MangoApiService.php
+++ b/src/Teknoo/MangoPayBundle/Service/MangoApiService.php
@@ -35,6 +35,8 @@ use MangoPay\MangoPayApi;
  *
  * @license     http://teknoo.software/license/mit         MIT License
  * @author      Richard Déloge <richarddeloge@gmail.com>
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class MangoApiService
 {
@@ -169,8 +171,18 @@ class MangoApiService
 
     /**
      * @return \MangoPay\ApiTransfers
+     * @deprecated Deprecated in 1.1, to be removed in 2.0
      */
     public function getApiTransferts()
+    {
+        @trigger_error('The ' . __METHOD__ . ' method has been deprecated in 1.1 and will be removed in 2.0.');
+        return $this->getApiTransfers();
+    }
+
+    /**
+     * @return \MangoPay\ApiTransfers
+     */
+    public function getApiTransfers()
     {
         return $this->api->Transfers;
     }

--- a/src/Teknoo/MangoPayBundle/Service/MangoApiService.php
+++ b/src/Teknoo/MangoPayBundle/Service/MangoApiService.php
@@ -206,4 +206,84 @@ class MangoApiService
     {
         return $this->api->Refunds;
     }
+
+    /**
+     * @return \MangoPay\ApiBankingAliases
+     */
+    public function getApiBankingAliases()
+    {
+        return $this->api->BankingAliases;
+    }
+
+    /**
+     * @return \MangoPay\ApiHooks
+     */
+    public function getApiHooks()
+    {
+        return $this->api->Hooks;
+    }
+
+    /**
+     * @return \MangoPay\ApiResponses
+     */
+    public function getApiResponses()
+    {
+        return $this->api->Responses;
+    }
+
+    /**
+     * @return \MangoPay\ApiKycDocuments
+     */
+    public function getApiKycDocuments()
+    {
+        return $this->api->KycDocuments;
+    }
+
+    /**
+     * @return \MangoPay\ApiClients
+     */
+    public function getApiClients()
+    {
+        return $this->api->Clients;
+    }
+
+    /**
+     * @return \MangoPay\ApiEvents
+     */
+    public function getApiEvents()
+    {
+        return $this->api->Events;
+    }
+
+    /**
+     * @return \MangoPay\ApiDisputes
+     */
+    public function getApiDisputes()
+    {
+        return $this->api->Disputes;
+    }
+
+    /**
+     * @return \MangoPay\ApiDisputeDocuments
+     */
+    public function getApiDisputeDocuments()
+    {
+        return $this->api->DisputeDocuments;
+    }
+
+    /**
+     * @return \MangoPay\ApiMandates
+     */
+    public function getApiMandates()
+    {
+        return $this->api->Mandates;
+    }
+
+    /**
+     * @return \MangoPay\ApiReports
+     */
+    public function getApiReports()
+    {
+        return $this->api->Reports;
+    }
 }

--- a/tests/Service/MangoApiServiceTest.php
+++ b/tests/Service/MangoApiServiceTest.php
@@ -166,12 +166,12 @@ class MangoApiServiceTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetApiTransferts()
+    public function testGetApiTransfers()
     {
         $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
         self::assertSame(
             $this->getMangoPayApiMock()->Transfers,
-            $service->getApiTransferts()
+            $service->getApiTransfers()
         );
     }
 

--- a/tests/Service/MangoApiServiceTest.php
+++ b/tests/Service/MangoApiServiceTest.php
@@ -210,4 +210,94 @@ class MangoApiServiceTest extends \PHPUnit\Framework\TestCase
             $service->getApiRefunds()
         );
     }
+
+    public function testGetApiBankingAliases()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock()->BankingAliases,
+            $service->getApiBankingAliases()
+        );
+    }
+
+    public function testGetApiHooks()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock()->Hooks,
+            $service->getApiHooks()
+        );
+    }
+
+    public function testGetApiResponses()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock()->Responses,
+            $service->getApiResponses()
+        );
+    }
+
+    public function testGetApiKycDocuments()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock()->KycDocuments,
+            $service->getApiKycDocuments()
+        );
+    }
+
+    public function testGetApiClients()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock()->Clients,
+            $service->getApiClients()
+        );
+    }
+
+    public function testGetApiEvents()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock()->Events,
+            $service->getApiEvents()
+        );
+    }
+
+    public function testGetApiDisputes()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock()->Disputes,
+            $service->getApiDisputes()
+        );
+    }
+
+    public function testGetApiDisputeDocuments()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock()->DisputeDocuments,
+            $service->getApiDisputeDocuments()
+        );
+    }
+
+    public function testGetApiMandates()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock()->Mandates,
+            $service->getApiMandates()
+        );
+    }
+
+    public function testGetApiReports()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock()->Reports,
+            $service->getApiReports()
+        );
+    }
 }


### PR DESCRIPTION
This pull request adds a bunch of missing API services. It also fixes a typo in the transfer API service name, deprecating the old service name properly for removal in 2.0.