### PR TITLE
Inject logger into SDK service

### DIFF
--- a/src/Teknoo/MangoPayBundle/Resources/config/services.yml
+++ b/src/Teknoo/MangoPayBundle/Resources/config/services.yml
@@ -34,6 +34,10 @@ services:
   #mango pay sdk instance
   mangopay.sdk.mango_pay_api.service:
     class: "%mangopay.sdk.mango_pay_api.class%"
+    calls:
+      - [setLogger, ['@?logger']]
+    tags:
+      - { name: monolog.logger, channel: mangopay }
 
   mangopay.sdk.api_user.service:
       class: "%mangopay.sdk.api_user.class%"


### PR DESCRIPTION
This pull request optionally injects the logger service into the MangoPay SDK, configuring a `mangopay` channel in the process. The call is marked as optional, so it will not be executed if no logger is set in the container.