### PR TITLE
Allow declaring a http client for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ This library requires :
     * Symfony 2.7+
     * Mango Pay API
 
+Testing
+-------
+To make the bundle testable without connecting to the official API simply create a service named `mangopay.sdk.http_client`.
+This client must implement `MangoPay\Libraries\HttpBase`.
+
 Credits
 -------
 Richard Déloge - <richarddeloge@gmail.com> - Lead developer.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "mangopay/php-sdk-v2": "~2.1"
+        "mangopay/php-sdk-v2": "~2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "6.2",

--- a/src/Teknoo/MangoPayBundle/Resources/config/services.yml
+++ b/src/Teknoo/MangoPayBundle/Resources/config/services.yml
@@ -34,6 +34,8 @@ services:
   #mango pay sdk instance
   mangopay.sdk.mango_pay_api.service:
     class: "%mangopay.sdk.mango_pay_api.class%"
+    calls:
+      - [setHttpClient, ['@?mangopay.sdk.http_client']]
 
   mangopay.sdk.api_user.service:
       class: "%mangopay.sdk.api_user.class%"


### PR DESCRIPTION
This allows you to declare a service that will automatically be injected into the SDK API if it has been defined. If the service is not defined, the default client will be used.