### PR TITLE
Fix YAML deprecation warning

### DIFF
--- a/src/Teknoo/MangoPayBundle/Resources/config/services.yml
+++ b/src/Teknoo/MangoPayBundle/Resources/config/services.yml
@@ -67,13 +67,13 @@ services:
     class: "%mangopay.sdk.api_pay_outs.class%"
     factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiPayOuts']
 
-  mangopay.sdk.api_transfers.service:
+  mangopay.sdk.api_transfert.service:
     class: "%mangopay.sdk.api_transfert.class%"
     factory: ['@teknoo.mangopaybundle.service.mango_api', 'getApiTransfers']
+    deprecated: The "%service_id%" service is deprecated since 1.1 and will be removed in 2.0. Please use the "mangopay.sdk.api_transfers.service" service instead.
 
-  mangopay.sdk.api_transfert.service:
-    alias: 'mangopay.sdk.api_transfers.service'
-    deprecated: The "%service_id%" service is deprecated since 1.1 and will be removed in 2.0.
+  mangopay.sdk.api_transfers.service:
+    alias: 'mangopay.sdk.api_transfert.service'
 
   mangopay.sdk.api_cards.service:
     class: "%mangopay.sdk.api_cards.class%"


### PR DESCRIPTION
See error message:

> The configuration key "deprecated" is unsupported for the service "mangopay.sdk.api_transfert.service" which is defined as an alias in "vendor/teknoo/mango-pay-bundle/src/Teknoo/MangoPayBundle/DependencyInjection/../Resources/config/services.yml". Allowed configuration keys for service aliases are "alias" and "public". The YamlFileLoader will raise an exception in Symfony 4.0, instead of silently ignoring unsupported attributes.