### PR TITLE
Add getApi getter to MangoApiService

### DIFF
--- a/src/Teknoo/MangoPayBundle/Service/MangoApiService.php
+++ b/src/Teknoo/MangoPayBundle/Service/MangoApiService.php
@@ -113,6 +113,11 @@ class MangoApiService
         return $this;
     }
 
+    public function getApi(): MangoPayApi
+    {
+        return $this->api;
+    }
+
     /**
      * @return string
      */

--- a/tests/Service/MangoApiServiceTest.php
+++ b/tests/Service/MangoApiServiceTest.php
@@ -110,6 +110,15 @@ class MangoApiServiceTest extends \PHPUnit\Framework\TestCase
         $api->OAuthTokenManager->StoreToken($tokenMock);
     }
 
+    public function testGetApi()
+    {
+        $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);
+        self::assertSame(
+            $this->getMangoPayApiMock(),
+            $service->getApi()
+        );
+    }
+
     public function testGetClientId()
     {
         $service = $this->buildService('clientIdValue', 'clientPassPhraseValue', 'http://foo.bar.com', true);


### PR DESCRIPTION
It's huge pain to use this bundle because every time there is mangopay SDK change, there is big delay before this is implemented here. This change will help lessen this pain, because this will allow to access core SDK for functionalities not yet implemented in bundle.